### PR TITLE
Fix DETCI integral transformation setup

### DIFF
--- a/psi4/src/psi4/detci/ints.cc
+++ b/psi4/src/psi4/detci/ints.cc
@@ -326,9 +326,6 @@ void CIWavefunction::setup_mcscf_ints() {
     std::vector<int> rot_orbitals(CalcInfo_->num_rot_orbs, 0);
     std::vector<int> act_orbitals(CalcInfo_->num_ci_orbs, 0);
 
-    // Indices *should* be zero, DPD does not use it
-    std::vector<int> indices(CalcInfo_->num_ci_orbs, 0);
-
     int act_orbnum = 0;
     int rot_orbnum = 0;
     for (int h = 0, rn = 0, an = 0; h < CalcInfo_->nirreps; h++) {
@@ -348,8 +345,8 @@ void CIWavefunction::setup_mcscf_ints() {
         rot_orbnum += CalcInfo_->frozen_uocc[h];
     }
 
-    rot_space_ = std::make_shared<MOSpace>('R', rot_orbitals, indices);
-    act_space_ = std::make_shared<MOSpace>('X', act_orbitals, indices);
+    rot_space_ = std::make_shared<MOSpace>('R', rot_orbitals, std::vector<int>());
+    act_space_ = std::make_shared<MOSpace>('X', act_orbitals, std::vector<int>());
     spaces.push_back(rot_space_);
     spaces.push_back(act_space_);
 

--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -275,7 +275,7 @@ void IntegralTransform::process_spaces() {
                         if (mosym_[orb] == h) {
                             aOrbsPI[h]++;
                             aOrbSym[count] = h;
-                            //if (aIndex) aIndex[count] = aindex[n];
+                            if (aIndex) aIndex[count] = aindex[n];
                             count++;
                         }
                     }


### PR DESCRIPTION
## Description
The orbital indexing bug turned out to be an issue with the way the library is setup in DETCI.  This fixes the problem and all of the problematic tests that you pointed out pass with ASAN enabled on my Mac.