### PR TITLE
Fix virtual orbital indexing for ROHF in libtrans

### DIFF
--- a/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
+++ b/psi4/src/psi4/libtrans/integraltransform_moinfo.cc
@@ -201,15 +201,12 @@ void IntegralTransform::process_spaces() {
             for (int h = 0; h < nirreps_; ++h) {
                 for (int n = 0; n < aOrbsPI[h]; ++n) {
                     if (transformationType_ == TransformationType::Restricted) {
-                        aPitzerCount = pitzerOffset + nalphapi_[h];
+                        aPitzerCount = pitzerOffset + nbetapi_[h];
                     } else {
                         aPitzerCount = pitzerOffset + nalphapi_[h];
                     }
                 }
                 for (int n = 0; n < aOrbsPI[h]; ++n) {
-
-                    if (qt_order && aPitzerCount >= nmo_) exit(42);
-
                     aIndex[aOrbCount++] = (qt_order ? aQT_[aPitzerCount] : aPitzerCount);
                     aPitzerCount++;
                 }


### PR DESCRIPTION
The problem was just a simple offset.  Thank you for finding the error :)